### PR TITLE
DevOps - Add gitpod as development environment

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image: gitpod/workspace-python-3.10
+tasks:
+  - init: python -m pip install -e . -r test_requirements.txt
+
+

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,19 @@
 image: gitpod/workspace-python-3.10
+
 tasks:
   - init: python -m pip install -e . -r test_requirements.txt
 
-
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to true)
+    addComment: false
+    # add a "Review in Gitpod" button to pull requests (defaults to false)
+    addBadge: true

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,3 +18,7 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+test:
+	pytest 
+

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,1 @@
+cookiecutter


### PR DESCRIPTION
## Description
Why was this PR created?
Gitpod is quite useful as a cloud development environment, it also come in handy for PR review where you have a sandbox created automatically.


## Development notes
What have you changed, and how has this been tested?
- add `test_requirements.txt` since `cookiecutter` is missing
- Add`.gitpod.yml` to setup the develop environment.

## Checklist

- [ ] Read the [contributing](../CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [ ] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](../CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [ ] Add tests to cover your changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
