### PR TITLE
Feature/allow converting

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ Welcome to kedro-pandera's documentation!
 
    Tutorial <source/01_tutorials/01_getting_started.md>
    DataFrameModel <source/01_tutorials/02_dataframe_model.md>
+   Convert Input Data <source/01_tutorials/03_convert_input_data.md>
 
 
 Indices and tables

--- a/docs/source/01_tutorials/03_convert_input_data.md
+++ b/docs/source/01_tutorials/03_convert_input_data.md
@@ -1,0 +1,83 @@
+# Convert Input Data
+Alongside data validation, we can utilize Pandera schemas to convert the data types of our input dataframe with those defined in the schema.
+
+
+## Configuration
+
+To ensure conversion of all datasets with a provided pandera schema, a global parameter can be set in the parameters.yml file.
+```yaml
+pandera:
+  convert: True
+```
+
+Each dataset can be uniquely configured within the `catalog.yml`. Configurations set at the dataset level take precedence over global settings.
+
+Example:
+```yaml
+example_iris_data:
+  type: pandas.CSVDataset
+  filepath: data/01_raw/iris.csv
+  metadata:
+    pandera:
+      schema: ${pa.yaml:_example_iris_data_schema}
+      convert: True
+```
+
+
+## Example
+
+In the iris dataset the species column will be converted to object type by default when no data types are provided.
+
+```yaml
+example_iris_data:
+  type: pandas.CSVDataset
+  filepath: data/01_raw/iris.csv
+```
+
+Data types in the node without conversion:
+```python
+example_iris_data.dtypes()
+```
+output:
+```bash
+sepal_length    float64
+sepal_width     float64
+petal_length    float64
+petal_width     float64
+species          object
+dtype: object
+```
+
+If we would like to convert the species column to string we can define the data type in the schema:
+```yaml
+...
+  species:
+    dtype: string
+    nullable: false
+...
+```
+
+And enable converting in the catalog:
+```yaml
+example_iris_data:
+  type: pandas.CSVDataset
+  filepath: data/01_raw/iris.csv
+  metadata:
+    pandera:
+      schema: ${pa.yaml:_example_iris_data_schema}
+      convert: True
+```
+
+Now the data type in the node will be according to the schema
+```python
+example_iris_data.dtypes()
+```
+output:
+```bash
+sepal_length           float64
+sepal_width            float64
+petal_length           float64
+petal_width            float64
+species         string[python]
+dtype: object
+```

--- a/tests/data/iris_schema.yml
+++ b/tests/data/iris_schema.yml
@@ -1,85 +1,84 @@
-_example_iris_data_schema:
-  schema_type: dataframe
-  version: 0.18.3
-  columns:
-    sepal_length:
-      title: null
-      description: null
-      dtype: float64
-      nullable: false
-      checks:
-        greater_than_or_equal_to: 4.3
-        less_than_or_equal_to: 7.9
-      unique: false
-      coerce: false
-      required: true
-      regex: false
-    sepal_width:
-      title: null
-      description: null
-      dtype: float64
-      nullable: false
-      checks:
-        greater_than_or_equal_to: 2.0
-        less_than_or_equal_to: 4.4
-      unique: false
-      coerce: false
-      required: true
-      regex: false
-    petal_length:
-      title: null
-      description: null
-      dtype: float64
-      nullable: false
-      checks:
-        greater_than_or_equal_to: 1.0
-        less_than_or_equal_to: 6.9
-      unique: false
-      coerce: false
-      required: true
-      regex: false
-    petal_width:
-      title: null
-      description: null
-      dtype: float64
-      nullable: false
-      checks:
-        greater_than_or_equal_to: 0.1
-        less_than_or_equal_to: 2.5
-      unique: false
-      coerce: false
-      required: true
-      regex: false
-    species:
-      title: null
-      description: null
-      dtype: object
-      nullable: false
-      checks: null
-      unique: false
-      coerce: false
-      required: true
-      regex: false
-  checks: null
-  index:
-  - title: null
+schema_type: dataframe
+version: 0.18.3
+columns:
+  sepal_length:
+    title: null
     description: null
-    dtype: int64
+    dtype: float32
     nullable: false
     checks:
-      greater_than_or_equal_to: 0.0
-      less_than_or_equal_to: 149.0
-    name: null
+      greater_than_or_equal_to: 4.3
+      less_than_or_equal_to: 7.9
     unique: false
     coerce: false
-  dtype: null
-  coerce: true
-  strict: false
-  name: null
-  ordered: false
-  unique: null
-  report_duplicates: all
-  unique_column_names: false
-  add_missing_columns: false
-  title: null
+    required: true
+    regex: false
+  sepal_width:
+    title: null
+    description: null
+    dtype: float64
+    nullable: false
+    checks:
+      greater_than_or_equal_to: 2.0
+      less_than_or_equal_to: 4.4
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  petal_length:
+    title: null
+    description: null
+    dtype: float64
+    nullable: false
+    checks:
+      greater_than_or_equal_to: 1.0
+      less_than_or_equal_to: 6.9
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  petal_width:
+    title: null
+    description: null
+    dtype: float64
+    nullable: false
+    checks:
+      greater_than_or_equal_to: 0.1
+      less_than_or_equal_to: 2.5
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  species:
+    title: null
+    description: null
+    dtype: string
+    nullable: false
+    checks: null
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+checks: null
+index:
+- title: null
   description: null
+  dtype: int64
+  nullable: false
+  checks:
+    greater_than_or_equal_to: 0.0
+    less_than_or_equal_to: 149.0
+  name: null
+  unique: false
+  coerce: false
+dtype: null
+coerce: true
+strict: false
+name: null
+ordered: false
+unique: null
+report_duplicates: all
+unique_column_names: false
+add_missing_columns: false
+title: null
+description: null

--- a/tests/data/iris_schema_fail.yml
+++ b/tests/data/iris_schema_fail.yml
@@ -1,0 +1,85 @@
+schema_type: dataframe
+version: 0.18.3
+columns:
+  sepal_length:
+    title: null
+    description: null
+    dtype: float32
+    nullable: false
+    checks:
+      greater_than_or_equal_to: 4.3
+      less_than_or_equal_to: 7.9
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  sepal_width:
+    title: null
+    description: null
+    dtype: float64
+    nullable: false
+    checks:
+      greater_than_or_equal_to: 2.0
+      less_than_or_equal_to: 4.4
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  petal_length:
+    title: null
+    description: null
+    dtype: float64
+    nullable: false
+    checks:
+      greater_than_or_equal_to: 1.0
+      less_than_or_equal_to: 6.9
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  petal_width:
+    title: null
+    description: null
+    dtype: float64
+    nullable: false
+    checks:
+      greater_than_or_equal_to: 0.1
+      less_than_or_equal_to: 2.5
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  species:
+    title: null
+    description: null
+    dtype: string
+    nullable: false
+    checks:
+      isin: ["satosa", "versicolor", "virginica"]
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+checks: null
+index:
+- title: null
+  description: null
+  dtype: int64
+  nullable: false
+  checks:
+    greater_than_or_equal_to: 0.0
+    less_than_or_equal_to: 149.0
+  name: null
+  unique: false
+  coerce: false
+dtype: null
+coerce: true
+strict: false
+name: null
+ordered: false
+unique: null
+report_duplicates: all
+unique_column_names: false
+add_missing_columns: false
+title: null
+description: null

--- a/tests/framework/hooks/test_hook.py
+++ b/tests/framework/hooks/test_hook.py
@@ -1,23 +1,38 @@
 import pandas as pd
+import pytest
 from kedro.io import DataCatalog
+from kedro.io.memory_dataset import MemoryDataset
 from kedro.pipeline import node
 from kedro_datasets.pandas import CSVDataset
+from pandera.errors import SchemaError
 from pandera.io import from_yaml
 
 from kedro_pandera.framework.hooks.pandera_hook import PanderaHook
 
 
-def _run_hook(csv_file, schema_file, convert=False):
+def _get_test_catalog(csv_file, schema_file, convert=False):
     test_schema = from_yaml(schema_file)
     test_catalog = DataCatalog(
         {
             "iris": CSVDataset(
                 filepath=csv_file,
                 metadata={"pandera": {"schema": test_schema, "convert": convert}},
-            )
+            ),
+            "params:pandera": MemoryDataset(data={"convert": False}),
         }
     )
+    return test_catalog
+
+
+def _get_test_hook(test_catalog):
     test_hook = PanderaHook()
+    test_hook.after_catalog_created(test_catalog)
+    return test_hook
+
+
+def _run_hook(csv_file, schema_file, convert=False):
+    test_catalog = _get_test_catalog(csv_file, schema_file, convert)
+    test_hook = _get_test_hook(test_catalog)
     test_inputs = {"iris": test_catalog.load("iris")}
     test_node = node(
         name="test_node", func=lambda iris: True, inputs=["iris"], outputs=None
@@ -38,6 +53,51 @@ def test_hook():
         schema_file="tests/data/iris_schema.yml",
         convert=False,
     )
+
+
+def test_hook_validation_error():
+    with pytest.raises(SchemaError):
+        _run_hook(
+            csv_file="tests/data/iris.csv",
+            schema_file="tests/data/iris_schema_fail.yml",
+            convert=False,
+        )
+
+
+def test_hook_unexpected_error():
+    test_catalog = _get_test_catalog(
+        csv_file="tests/data/iris.csv", schema_file="tests/data/iris_schema.yml"
+    )
+    test_hook = _get_test_hook(test_catalog)
+    test_inputs = {"iris": []}
+    test_node = node(
+        name="test_node", func=lambda iris: True, inputs=["iris"], outputs=None
+    )
+    with pytest.raises(Exception):
+        test_hook.before_node_run(
+            node=test_node,
+            catalog=test_catalog,
+            inputs=test_inputs,
+            is_async=False,
+            session_id=0,
+        )
+
+
+def test_hook_output_data_not_in_catalog():
+    test_catalog = _get_test_catalog(
+        csv_file="tests/data/iris.csv", schema_file="tests/data/iris_schema.yml"
+    )
+    test_hook = _get_test_hook(test_catalog)
+    test_outputs = {"output": []}
+    test_node = node(
+        name="test_node", func=lambda iris: True, inputs=["iris"], outputs=None
+    )
+    result = test_hook.after_node_run(
+        node=test_node,
+        catalog=test_catalog,
+        outputs=test_outputs,
+    )
+    assert result is None
 
 
 def test_hook_with_converting():

--- a/tests/framework/hooks/test_hook.py
+++ b/tests/framework/hooks/test_hook.py
@@ -1,3 +1,4 @@
+import pandas as pd
 from kedro.io import DataCatalog
 from kedro.pipeline import node
 from kedro_datasets.pandas import CSVDataset
@@ -6,13 +7,13 @@ from pandera.io import from_yaml
 from kedro_pandera.framework.hooks.pandera_hook import PanderaHook
 
 
-def test_hook():
-    test_schema = from_yaml("tests/data/iris_schema.yml")
+def _run_hook(csv_file, schema_file, convert=False):
+    test_schema = from_yaml(schema_file)
     test_catalog = DataCatalog(
         {
             "iris": CSVDataset(
-                filepath="tests/data/iris.csv",
-                metadata={"pandera": {"schema": test_schema}},
+                filepath=csv_file,
+                metadata={"pandera": {"schema": test_schema, "convert": convert}},
             )
         }
     )
@@ -21,10 +22,35 @@ def test_hook():
     test_node = node(
         name="test_node", func=lambda iris: True, inputs=["iris"], outputs=None
     )
-    test_hook.before_node_run(
+    converted_inputs = test_hook.before_node_run(
         node=test_node,
         catalog=test_catalog,
         inputs=test_inputs,
         is_async=False,
         session_id=0,
+    )
+    return test_inputs, converted_inputs
+
+
+def test_hook():
+    _run_hook(
+        csv_file="tests/data/iris.csv",
+        schema_file="tests/data/iris_schema.yml",
+        convert=False,
+    )
+
+
+def test_hook_with_converting():
+    test_inputs, converted_inputs = _run_hook(
+        csv_file="tests/data/iris.csv",
+        schema_file="tests/data/iris_schema.yml",
+        convert=True,
+    )
+    # test if species column is converted to string type
+    assert ~isinstance(
+        test_inputs["iris"].dtypes["species"], pd.core.arrays.string_.StringDtype
+    )
+    assert isinstance(
+        converted_inputs["iris"].dtypes["species"],
+        pd.core.arrays.string_.StringDtype,
     )


### PR DESCRIPTION
## Description
Allow converting input data according to the pandera schema so data types only need to be define in the schema and not also als load parameter. 

## Development notes
- Added reading of global and dataset parameter (convert)
- Added to return validated dataset when parameter is set
- Enabled validation + conversion also for output datasets
- Added unittest to test conversion example

## Checklist

- [ ] Read the [contributing](../CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [ ] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](../CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [ ] Add tests to cover your changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
