### PR TITLE
:bug: Fix AttributeError in datasets with missing metadata parameter (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- :bug: Fix `AttributeError` in datasets with missing `metadata` parameter ([#67](https://github.com/Galileo-Galilei/kedro-pandera/issues/67))
+
 ## [0.2.1] - 2024-05-06
 
 -   :bug: Fix dataset reference in hook for kedro >= 0.19.0

--- a/kedro_pandera/framework/hooks/pandera_hook.py
+++ b/kedro_pandera/framework/hooks/pandera_hook.py
@@ -55,13 +55,14 @@ class PanderaHook:
         self, node: Node, catalog: DataCatalog, datasets: Dict[str, Any]
     ):
         for name, data in datasets.items():
+            metadata = getattr(catalog._datasets[name], "metadata", None)
             if (
-                catalog._datasets[name].metadata is not None
-                and "pandera" in catalog._datasets[name].metadata
+                metadata is not None
+                and "pandera" in metadata
                 and name not in self._validated_datasets
             ):
                 try:
-                    catalog._datasets[name].metadata["pandera"]["schema"].validate(data)
+                    metadata["pandera"]["schema"].validate(data)
                     self._validated_datasets.add(name)
                 except SchemaError as err:
                     self._logger.error(


### PR DESCRIPTION
## Description
Why was this PR created?
Fix #67 

## Development notes
What have you changed, and how has this been tested?
- added `getattr()` with `None` as a default value for accessing `metadata`

## Checklist

- [ ] Read the [contributing](../CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [ ] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](../CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [ ] Add tests to cover your changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
