### PR TITLE
:bug: :white_check_mark: Fix KeyError on MemoryDataset outputs & add tests (#69)

### DIFF
--- a/kedro_pandera/framework/hooks/pandera_hook.py
+++ b/kedro_pandera/framework/hooks/pandera_hook.py
@@ -55,7 +55,8 @@ class PanderaHook:
         self, node: Node, catalog: DataCatalog, datasets: Dict[str, Any]
     ):
         for name, data in datasets.items():
-            metadata = getattr(catalog._datasets[name], "metadata", None)
+            dataset = catalog._datasets.get(name)
+            metadata = getattr(dataset, "metadata", None)
             if (
                 metadata is not None
                 and "pandera" in metadata


### PR DESCRIPTION
## Description
(#69)

## Development notes
What have you changed, and how has this been tested?
- used `.get()` on `catalog._datasets` to avoid `KeyError`
- added tests with the initial bug
- ran previously failing code (spaceflights-pandas kedro starter)

## Checklist

- [x] Read the [contributing](../CONTRIBUTING.md) guidelines
- [x] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](../CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
