### PR TITLE
Validate output factory datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+-   :bug: Fix not validating output factory datasets ([#80](https://github.com/Galileo-Galilei/kedro-pandera/issues/80))
+
 ## [0.2.2] - 2024-06-03
 
 ### Added

--- a/kedro_pandera/framework/hooks/pandera_hook.py
+++ b/kedro_pandera/framework/hooks/pandera_hook.py
@@ -55,7 +55,7 @@ class PanderaHook:
         self, node: Node, catalog: DataCatalog, datasets: Dict[str, Any]
     ):
         for name, data in datasets.items():
-            dataset = catalog._datasets.get(name)
+            dataset = catalog._get_dataset(name)
             metadata = getattr(dataset, "metadata", None)
             if (
                 metadata is not None


### PR DESCRIPTION
## Description
Fixes #80

## Development notes
Now, the internal catalog function `_get_datasets()` is used instead of `_datasets.get()`, which automatically resolves dataset factory patterns and populates the catalog with these datasets.

## Checklist

- [x] Read the [contributing](../CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](../CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [x] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
