### PR TITLE
chore: remove python upper bound and support up to 3.13

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.13]
     env:
       PYTHON_PACKAGE: kedro_pandera
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: "3.13"
     - name: Build package dist from source # A better way will be : https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ but pep 517 is still marked as experimental
       run: |
         pip install wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       OS: ${{ matrix.os }}
@@ -30,11 +30,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[test]
     - name: Check code formatting with ruff
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' # linting should occur only once in the loop
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' # linting should occur only once in the loop
       run: |
         ruff format . --check
     - name: Check import order and syntax with ruff
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' # linting should occur only once in the loop
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' # linting should occur only once in the loop
       #"F",  # Pyflakes
       #"E",  # Pycodestyle
       # "W",  # Pycodestyle
@@ -50,7 +50,7 @@ jobs:
         pytest --cov=./ --cov-report=xml
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v4
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' # upload should occur only once in the loop
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' # upload should occur only once in the loop
       with:
         token: ${{ secrets.CODECOV_TOKEN }}  # token is not mandatory but make access more stable
         # use_oidc: true would better?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Addded
+
+- :sparkles: Remove upper bound on Python version and support up to 3.13 ([#92](https://github.com/Galileo-Galilei/kedro-pandera/pull/92))
+
 ## [0.2.3] - 2024-07-18
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,9 @@ setup(
         "test": [
             "ruff>=0.5.0, <0.6.0",
             "pyspark>=2.2, <4.0",
+            "pyarrow>=4.0.0",
+            "protobuf",
+            "grpcio>=1.48.1",
             "pytest>=7.0.0, <9.0.0",
             "pytest-cov>=4.0.0, <6.0.0",
             "pytest-mock",
@@ -80,6 +83,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Framework :: Kedro",
         "Environment :: Plugins",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     url="https://github.com/Galileo-Galilei/kedro-pandera",
-    python_requires=">=3.8, <3.12",
+    python_requires=">=3.8",
     packages=find_packages(exclude=["docs*", "tests*"]),
     setup_requires=["setuptools_scm"],
     include_package_data=True,


### PR DESCRIPTION
## Description
Removes python upper bound and adds support for Python up to 3.13

## Development notes
There is no reason to have a cap on python version. Rarely anything breaks between updates.
Updated CI to run on 3.13, ran tests locally against 3.13

## Checklist

- [x] Read the [contributing](../CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [x] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](../CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [ ] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
